### PR TITLE
FEAT: Adding camel case in VS Code

### DIFF
--- a/src/vs/editor/contrib/linesOperations/browser/linesOperations.ts
+++ b/src/vs/editor/contrib/linesOperations/browser/linesOperations.ts
@@ -1162,6 +1162,38 @@ export class SnakeCaseAction extends AbstractCaseAction {
 	}
 }
 
+export class CamelCaseAction extends AbstractCaseAction {
+
+	public static caseBoundary = new BackwardsCompatibleRegExp('(\\p{Ll})(\\p{Lu})', 'gmu');
+	public static singleLetters = new BackwardsCompatibleRegExp('(\\p{Lu}|\\p{N})(\\p{Lu})(\\p{Ll})', 'gmu');
+
+	constructor() {
+		super({
+			id: 'editor.action.transformToCamelcase',
+			label: nls.localize('editor.transformToCamelcase', "Transform to Camel Case"),
+			alias: 'Transform to Camel Case',
+			precondition: EditorContextKeys.writable
+		});
+	}
+
+	protected _modifyText(text: string, wordSeparators: string): string {
+		const caseBoundary = CamelCaseAction.caseBoundary.get();
+		const singleLetters = CamelCaseAction.singleLetters.get();
+		if (!caseBoundary || !singleLetters) {
+			// cannot support this
+			return text;
+		}
+		return (text
+			.replace(caseBoundary, function(a) {
+		  		return a.toUpperCase();
+			})
+			.replace(singleLetters, function(b) {
+				return b.toLowerCase();
+			})
+		);
+	}
+}
+
 registerEditorAction(CopyLinesUpAction);
 registerEditorAction(CopyLinesDownAction);
 registerEditorAction(DuplicateSelectionAction);
@@ -1185,6 +1217,9 @@ registerEditorAction(LowerCaseAction);
 
 if (SnakeCaseAction.caseBoundary.isSupported() && SnakeCaseAction.singleLetters.isSupported()) {
 	registerEditorAction(SnakeCaseAction);
+}
+if (CamelCaseAction.caseBoundary.isSupported() && CamelCaseAction.singleLetters.isSupported()) {
+	registerEditorAction(CamelCaseAction);
 }
 if (TitleCaseAction.titleBoundary.isSupported()) {
 	registerEditorAction(TitleCaseAction);

--- a/src/vs/editor/contrib/linesOperations/test/browser/linesOperations.test.ts
+++ b/src/vs/editor/contrib/linesOperations/test/browser/linesOperations.test.ts
@@ -11,7 +11,7 @@ import { Selection } from 'vs/editor/common/core/selection';
 import { Handler } from 'vs/editor/common/editorCommon';
 import { ITextModel } from 'vs/editor/common/model';
 import { ViewModel } from 'vs/editor/common/viewModel/viewModelImpl';
-import { DeleteAllLeftAction, DeleteAllRightAction, DeleteDuplicateLinesAction, DeleteLinesAction, IndentLinesAction, InsertLineAfterAction, InsertLineBeforeAction, JoinLinesAction, LowerCaseAction, SnakeCaseAction, SortLinesAscendingAction, SortLinesDescendingAction, TitleCaseAction, TransposeAction, UpperCaseAction } from 'vs/editor/contrib/linesOperations/browser/linesOperations';
+import {CamelCaseAction, DeleteAllLeftAction, DeleteAllRightAction, DeleteDuplicateLinesAction, DeleteLinesAction, IndentLinesAction, InsertLineAfterAction, InsertLineBeforeAction, JoinLinesAction, LowerCaseAction, SnakeCaseAction, SortLinesAscendingAction, SortLinesDescendingAction, TitleCaseAction, TransposeAction, UpperCaseAction} from 'vs/editor/contrib/linesOperations/browser/linesOperations';
 import { withTestCodeEditor } from 'vs/editor/test/browser/testCodeEditor';
 import { createTextModel } from 'vs/editor/test/common/testTextModel';
 
@@ -620,6 +620,7 @@ suite('Editor Contrib - Line Operations', () => {
 				let lowercaseAction = new LowerCaseAction();
 				let titlecaseAction = new TitleCaseAction();
 				let snakecaseAction = new SnakeCaseAction();
+				let camelcaseAction = new CamelCaseAction();
 
 				editor.setSelection(new Selection(1, 1, 1, 12));
 				executeAction(uppercaseAction, editor);
@@ -737,6 +738,84 @@ suite('Editor Contrib - Line Operations', () => {
 				editor.setSelection(new Selection(20, 1, 20, 28));
 				executeAction(snakecaseAction, editor);
 				assert.strictEqual(model.getLineContent(20), '_accessor: services_accessor');
+				assertSelection(editor, new Selection(20, 1, 20, 29));
+
+				editor.setSelection(new Selection(3, 1, 3, 16));
+				executeAction(camelcaseAction, editor);
+				assert.strictEqual(model.getLineContent(3), 'parseHtmlString');
+				assertSelection(editor, new Selection(3, 1, 3, 18));
+
+				editor.setSelection(new Selection(4, 1, 4, 15));
+				executeAction(camelcaseAction, editor);
+				assert.strictEqual(model.getLineContent(4), 'getElementById');
+				assertSelection(editor, new Selection(4, 1, 4, 18));
+
+				editor.setSelection(new Selection(5, 1, 5, 11));
+				executeAction(camelcaseAction, editor);
+				assert.strictEqual(model.getLineContent(5), 'insertHtml');
+				assertSelection(editor, new Selection(5, 1, 5, 12));
+
+				editor.setSelection(new Selection(6, 1, 6, 11));
+				executeAction(camelcaseAction, editor);
+				assert.strictEqual(model.getLineContent(6), 'pascalCase');
+				assertSelection(editor, new Selection(6, 1, 6, 12));
+
+				editor.setSelection(new Selection(7, 1, 7, 17));
+				executeAction(camelcaseAction, editor);
+				assert.strictEqual(model.getLineContent(7), 'cssSelectorsList');
+				assertSelection(editor, new Selection(7, 1, 7, 19));
+
+				editor.setSelection(new Selection(8, 1, 8, 3));
+				executeAction(camelcaseAction, editor);
+				assert.strictEqual(model.getLineContent(8), 'iD');
+				assertSelection(editor, new Selection(8, 1, 8, 4));
+
+				editor.setSelection(new Selection(9, 1, 9, 5));
+				executeAction(camelcaseAction, editor);
+				assert.strictEqual(model.getLineContent(9), 'tEst');
+				assertSelection(editor, new Selection(9, 1, 9, 6));
+
+				editor.setSelection(new Selection(10, 1, 10, 11));
+				executeAction(camelcaseAction, editor);
+				assert.strictEqual(model.getLineContent(10), 'öçşÖçŞğüĞü');
+				assertSelection(editor, new Selection(10, 1, 10, 14));
+
+				editor.setSelection(new Selection(11, 1, 11, 34));
+				executeAction(camelcaseAction, editor);
+				assert.strictEqual(model.getLineContent(11), 'audioConverter.convertM4aToMp3();');
+				assertSelection(editor, new Selection(11, 1, 11, 38));
+
+				editor.setSelection(new Selection(12, 1, 12, 11));
+				executeAction(camelcaseAction, editor);
+				assert.strictEqual(model.getLineContent(12), 'snakeCase');
+				assertSelection(editor, new Selection(12, 1, 12, 11));
+
+				editor.setSelection(new Selection(13, 1, 13, 19));
+				executeAction(camelcaseAction, editor);
+				assert.strictEqual(model.getLineContent(13), 'capitalSnakeCase');
+				assertSelection(editor, new Selection(13, 1, 13, 19));
+
+				editor.setSelection(new Selection(14, 1, 17, 14));
+				executeAction(camelcaseAction, editor);
+				assert.strictEqual(model.getValueInRange(new Selection(14, 1, 17, 15)), `function helloWorld() {
+					return someGlobalObject.printHelloWorld("en", "utf-8");
+				}
+				helloWorld();`.replace(/^\s+/gm, ''));
+				assertSelection(editor, new Selection(14, 1, 17, 15));
+
+				editor.setSelection(new Selection(18, 1, 18, 13));
+				executeAction(camelcaseAction, editor);
+				assert.strictEqual(model.getLineContent(18), `'javaScript'`);
+				assertSelection(editor, new Selection(18, 1, 18, 14));
+
+				editor.setSelection(new Selection(19, 1, 19, 17));
+				executeAction(camelcaseAction, editor);
+				assert.strictEqual(model.getLineContent(19), 'parseHtml4String');
+				assertSelection(editor, new Selection(19, 1, 19, 19));
+
+				editor.setSelection(new Selection(20, 1, 20, 28));
+				executeAction(camelcaseAction, editor);
+				assert.strictEqual(model.getLineContent(20), '_accessor: servicesAccessor');
 				assertSelection(editor, new Selection(20, 1, 20, 29));
 			}
 		);


### PR DESCRIPTION
Currently, selecting any text and opening command palette to change case of text selection doesn't show any command to convert to camel case.

<img width="732" alt="Screenshot 2022-05-13 at 22 20 18" src="https://user-images.githubusercontent.com/7369612/168347201-e2ea5ef6-3a47-44ee-869d-9efdad2c429d.png">


<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #
<issue yet to be searched & linked>